### PR TITLE
Fix browser lib permissions

### DIFF
--- a/make-browser.sh
+++ b/make-browser.sh
@@ -37,6 +37,7 @@ cp native/blockstackProxy.js $OUTPATH
 echo "Install the CORS Proxy"
 mkdir -p $OUTPATH/corsproxy/node_modules
 npm install corsproxy --prefix $OUTPATH/corsproxy
+chmod -R 0555 $OUTPATH/corsproxy
 
 echo "Make run scripts"
 

--- a/make-browser.sh
+++ b/make-browser.sh
@@ -37,7 +37,7 @@ cp native/blockstackProxy.js $OUTPATH
 echo "Install the CORS Proxy"
 mkdir -p $OUTPATH/corsproxy/node_modules
 npm install corsproxy --prefix $OUTPATH/corsproxy
-chmod -R 0555 $OUTPATH/corsproxy
+chmod -R 0755 $OUTPATH/corsproxy
 
 echo "Make run scripts"
 


### PR DESCRIPTION
This one-liner fixes a problem with packaging of the cors-proxy, the node build script was making some files which wouldn't ultimately be readable by the user when trying to actually run the proxy.