### PR TITLE
Use a Docker-compose file for managing container interactions

### DIFF
--- a/browser-core-docker/README.md
+++ b/browser-core-docker/README.md
@@ -25,3 +25,21 @@ $ ./launcher stop
 ```
 
 This will start the Blockstack browser and a paired `blockstack-api` daemon.
+
+# Running a different Blockstack Version
+By default this script will launch the `latest`-tagged images. To use another version, do:
+
+```bash
+$ BLOCKSTACK_TAG=v0.17.1 ./launcher pull
+$ BLOCKSTACK_TAG=v0.17.1 ./launcher start
+$ ./launcher stop
+```
+
+# Storing data elsewhere
+By default, this script creates a `$HOME/.blockstack` directory for storing all data. To move that somewhere else, use the `BLOCKSTACK_DATA` environment variable:
+
+```bash
+$ ./launcher pull
+$ BLOCKSTACK_DATA=/mnt/data/blockstack ./launcher start
+$ ./launcher stop
+```

--- a/browser-core-docker/docker-compose.yml
+++ b/browser-core-docker/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "2"
+services:
+  core:
+    image: "${CORE_IMAGE}"
+    volumes:
+      - "${DATA_DIR}:/root/.blockstack"
+    command: "blockstack api start-foreground --password ${BLOCKSTACK_PASWD} --api_password ${BLOCKSTACK_PASWD}"
+    ports:
+      - "6270:6270"
+  browser-static:
+    image: "${BROWSER_IMAGE}"
+    command: "blockstack-browser"
+    ports:
+      - "8888:8888"
+  browser-cors:
+    image: "${BROWSER_IMAGE}"
+    command: "blockstack-cors-proxy"
+    environment:
+      CORSPROXY_HOST: "0.0.0.0"
+    ports:
+      - "1337:1337"

--- a/browser-core-docker/docker-compose.yml
+++ b/browser-core-docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: "${CORE_IMAGE}"
     volumes:
       - "${DATA_DIR}:/root/.blockstack"
-    command: "blockstack api start-foreground --password ${BLOCKSTACK_PASWD} --api_password ${BLOCKSTACK_PASWD}"
+    command: "blockstack api start-foreground --debug --password ${BLOCKSTACK_PASWD} --api_password ${BLOCKSTACK_PASWD}"
     ports:
       - "6270:6270"
   browser-static:

--- a/browser-core-docker/launcher
+++ b/browser-core-docker/launcher
@@ -64,7 +64,7 @@ start-containers () {
   elif [[ $(uname) == 'Darwin' ]]; then
     open "http://localhost:8888/#coreAPIPassword=$BLOCKSTACK_PASWD"
   elif [[ $(uname) == 'Windows' || $(uname) == 'MINGW64_NT-10.0' ]]; then
-    start "http://localhost:8888/#coreAPIPassword=$pBLOCKSTACK_PASWD"
+    start "http://localhost:8888/#coreAPIPassword=$BLOCKSTACK_PASWD"
   fi
 }
 

--- a/browser-core-docker/launcher
+++ b/browser-core-docker/launcher
@@ -109,7 +109,7 @@ IMPORTANT: This will be used to encrypt information stored within the containers
 EOF
   echo -n "Password: " ; read -s BLOCKSTACK_PASWD ; echo
   echo -n "Repeat: " ; read -s password_repeated ; echo
-  while [ ! $BLOCKSTACK_PASWD == $password_repeated ] ; do
+  while [ "$BLOCKSTACK_PASWD" != "$password_repeated" ] ; do
     echo "Passwords do not match, please try again."
     echo -n "Password: " ; read -s BLOCKSTACK_PASWD ; echo
     echo -n "Repeat: " ; read -s password_repeated ; echo

--- a/browser-core-docker/launcher
+++ b/browser-core-docker/launcher
@@ -32,7 +32,7 @@ create-wallet () {
   docker run --rm -v "${DATA_DIR}":/root/.blockstack $CORE_IMAGE blockstack setup -y --password $1
 
   # Use init containers to set the API bind to 0.0.0.0
-  docker run --rm -v "${DATA_DIR}":/root/.blockstack $CORE_IMAGE sed -i 's/api_endpoint_bind = localhost/api_endpoint_bind = 0.0.0.0/' $containerdir/client.ini
+  docker run --rm -v "${DATA_DIR}":/root/.blockstack $CORE_IMAGE sed -i 's/api_endpoint_bind = localhost/api_endpoint_bind = 0.0.0.0/' /root/.blockstack/client.ini
 }
 
 start-containers () {

--- a/browser-core-docker/launcher
+++ b/browser-core-docker/launcher
@@ -2,6 +2,7 @@
 
 # This script provides a simple interface for folks to use the docker install
 
+# Environment variables are marked as "export" such that the "docker" and "docker-compose" commands launched from this script can see them too
 if [ -z "${BLOCKSTACK_TAG}" ]; then
   export TAG=latest
 else

--- a/browser-core-docker/launcher
+++ b/browser-core-docker/launcher
@@ -2,153 +2,84 @@
 
 # This script provides a simple interface for folks to use the docker install
 
-TAG=latest
+if [ -z "${BLOCKSTACK_TAG}" ]; then
+  export TAG=latest
+else
+  export TAG=${BLOCKSTACK_TAG}
+fi
+export CORETAG="$TAG-browser"
 
-CORETAG="$TAG-browser"
-
-coreimage=quay.io/blockstack/blockstack-core:$CORETAG
-browserimage=quay.io/blockstack/blockstack-browser:$TAG
+export CORE_IMAGE=quay.io/blockstack/blockstack-core:$CORETAG
+export BROWSER_IMAGE=quay.io/blockstack/blockstack-browser:$TAG
 
 # Local Blockstack directory
-homedir=$HOME/.blockstack
-# Blockstack Directory inside container
-containerdir=/root/.blockstack
-# Name of Blockstack API container
-corecontainer=blockstack-api
-# Name of Blockstack Browser container
-browsercontainer=blockstack-browser
-# Local temporary directory
-tmpdir=/tmp/.blockstack_tmp
-if [ ! -e $tmpdir ]; then
-   mkdir -p $tmpdir
+if [ -z "${BLOCKSTACK_DATA}" ]; then
+  export DATA_DIR="$HOME/.blockstack"
+else
+  export DATA_DIR=${BLOCKSTACK_DATA}
 fi
+
 # set password blank so we know when to prompt
-password=0
+export BLOCKSTACK_PASWD=0
 
-
-build () {
-  echo "Building blockstack docker image. This might take a minute..."
-  docker build -t $browserimage .
-}
 
 create-wallet () {
   if [ $# -eq 0 ]; then
     echo "Need to input new wallet password when running setup: ./launcher create-wallet mypass"
     exit 1
   fi
-  docker run -it -v "$homedir":$containerdir $coreimage blockstack setup -y --password $1
+  docker run --rm -v "${DATA_DIR}":/root/.blockstack $CORE_IMAGE blockstack setup -y --password $1
 
   # Use init containers to set the API bind to 0.0.0.0
-  docker run -it -v "$homedir":$containerdir $coreimage sed -i 's/api_endpoint_bind = localhost/api_endpoint_bind = 0.0.0.0/' $containerdir/client.ini
+  docker run --rm -v "${DATA_DIR}":/root/.blockstack $CORE_IMAGE sed -i 's/api_endpoint_bind = localhost/api_endpoint_bind = 0.0.0.0/' $containerdir/client.ini
 }
 
 start-containers () {
   # Check for args first
   if [ $# -ne 0 ]; then
-      password=$1
+      BLOCKSTACK_PASWD=$1
   fi
 
   # let's see if we should create a new wallet
-  if [ ! -e "$homedir/wallet.json" ]; then
-    if [ $password == "0" ]; then
+  if [ ! -e "$DATA_DIR/wallet.json" ]; then
+    if [ $BLOCKSTACK_PASWD == "0" ]; then
       prompt-new-password
     fi
     echo "Wallet does not exist yet. Setting up wallet"
-    create-wallet $password
+    create-wallet $BLOCKSTACK_PASWD
   fi
 
   # otherwise, prompt for an OLD password
-  if [ $password == "0" ]; then
-      prompt-password
+  if [ $BLOCKSTACK_PASWD == "0" ]; then
+    prompt-password
   fi
 
-  # Check for the blockstack-api container is running or stopped.
-  if [ "$(docker ps -q -f name=$corecontainer)" ]; then
-    echo "blockstack core container is already running"
-    exit 1
-  elif [ ! "$(docker ps -q -f name=$corecontainer)" ]; then
-    if [ "$(docker ps -aq -f status=exited -f name=$corecontainer)" ]; then
-      # cleanup old container if its still around
-      echo "removing old blockstack-core container..."
-      docker rm $corecontainer
-    fi
+  # launch the containers
+  docker-compose -p blockstack up -d
 
-    if [ "$BLOCKSTACK_DEBUG" == "1" ]; then
-      runcommand="bash"
-    else
-      runcommand="blockstack api start-foreground --password $password --api_password $password"
-    fi
-
-    # If there is no existing $corecontainer container, run one
-    if [[ $(uname) == 'Linux' ]]; then
-      docker run -dt --name $corecontainer -v "$tmpdir":/tmp -v "$homedir":$containerdir -p 6270:6270 $coreimage $runcommand
-    elif [[ $(uname) == 'Darwin' ]]; then
-      docker run -dt --name $corecontainer -v "$tmpdir":/tmp -v "$homedir":$containerdir -p 6270:6270 $coreimage $runcommand
-    elif [[ $(uname) == 'Windows' || $(uname) == 'MINGW64_NT-10.0' ]]; then
-      docker run -dt --name $corecontainer -v "$tmpdir":/tmp -v "$homedir":$containerdir -p 6270:6270 $coreimage $runcommand
-    fi
-
-    if [ "$BLOCKSTACK_DEBUG" == "1" ]; then
-      docker exec -t $corecontainer blockstack api start --debug --password $password --api_password $password
-    fi
-  fi
-
-  # Check for the blockstack-browser-* containers are running or stopped.
-  if [ "$(docker ps -q -f name=$browsercontainer)" ]; then
-    echo "browser containers are already running"
-    exit 1
-  elif [ ! "$(docker ps -q -f name=$browsercontainer)" ]; then
-    if [ "$(docker ps -aq -f status=exited -f name=$browsercontainer)" ]; then
-      # cleanup old containers if they are still around
-      echo "removing old browser containers..."
-      docker rm $(docker ps -aq -f status=exited -f name=$browsercontainer)
-    fi
-
-    # If there are no existing blockstack-browser-* containers, run them
-    docker run -d --name $browsercontainer-static -p 8888:8888 $browserimage blockstack-browser
-    docker run -d --name $browsercontainer-cors  -e CORSPROXY_HOST="0.0.0.0" -p 1337:1337 $browserimage blockstack-cors-proxy
-
-    if [[ $(uname) == 'Linux' ]]; then
-      # let's register the protocol handler if it isn't already registered:
-      create-linux-protocol-handler
-      sensible-browser "http://localhost:8888/#coreAPIPassword=$password"
-    elif [[ $(uname) == 'Darwin' ]]; then
-      open "http://localhost:8888/#coreAPIPassword=$password"
-    elif [[ $(uname) == 'Windows' || $(uname) == 'MINGW64_NT-10.0' ]]; then
-      start "http://localhost:8888/#coreAPIPassword=$password"
-    fi
+  if [[ $(uname) == 'Linux' ]]; then
+    # let's register the protocol handler if it isn't already registered:
+    create-linux-protocol-handler
+    sensible-browser "http://localhost:8888/#coreAPIPassword=$BLOCKSTACK_PASWD"
+  elif [[ $(uname) == 'Darwin' ]]; then
+    open "http://localhost:8888/#coreAPIPassword=$BLOCKSTACK_PASWD"
+  elif [[ $(uname) == 'Windows' || $(uname) == 'MINGW64_NT-10.0' ]]; then
+    start "http://localhost:8888/#coreAPIPassword=$pBLOCKSTACK_PASWD"
   fi
 }
 
 stop () {
-  bc=$(docker ps -a -f name=$browsercontainer -q)
-  cc=$(docker ps -f name=$corecontainer -q)
-  if [ ! -z "$cc" ]; then
-    echo "stopping the running blockstack-api container"
-    docker stop $cc
-    docker rm $cc
-  fi
-
-  if [ ! -z "$bc" ]; then
-    echo "stopping the running blockstack-browser containers"
-    docker stop $bc
-    docker rm $bc
-  fi
+  docker-compose -p blockstack stop
 }
 
 enter () {
   echo "entering docker container"
-  docker exec -it $browsercontainer-static /bin/bash
+  docker-compose -p blockstack exec browser-static /bin/bash
 }
 
 logs () {
   echo "streaming logs for blockstack-api container"
-  docker logs $browsercontainer-static -f
-}
-
-push () {
-  echo "pushing build container up to quay.io..."
-  docker push $browserimage
+  docker-compose -p blockstack logs -f browser-static
 }
 
 commands () {
@@ -176,22 +107,21 @@ IMPORTANT: This will be used to encrypt information stored within the containers
                letters (upper and lowercase), numbers, '_', and '-'
 
 EOF
-  echo -n "Password: " ; read -s password ; echo
+  echo -n "Password: " ; read -s BLOCKSTACK_PASWD ; echo
   echo -n "Repeat: " ; read -s password_repeated ; echo
-  while [ ! $password == $password_repeated ] ; do
-      echo "Passwords do not match, please try again."
-      echo -n "Password: " ; read -s password ; echo
-      echo -n "Repeat: " ; read -s password_repeated ; echo
+  while [ ! $BLOCKSTACK_PASWD == $password_repeated ] ; do
+    echo "Passwords do not match, please try again."
+    echo -n "Password: " ; read -s BLOCKSTACK_PASWD ; echo
+    echo -n "Repeat: " ; read -s password_repeated ; echo
   done
 }
 
 prompt-password () {
-  echo "Enter your Blockstack Core password: " ; read -s password; echo
+  echo "Enter your Blockstack Core password: " ; read -s BLOCKSTACK_PASWD; echo
 }
 
 pull () {
-    docker pull ${coreimage}
-    docker pull ${browserimage}
+  docker-compose pull
 }
 
 version () {
@@ -199,13 +129,13 @@ version () {
 }
 
 create-linux-protocol-handler () {
-    HANDLER="blockstack.desktop"
-    if [ ! -e "$HOME/.local/share/applications/$HANDLER" ]; then
-       echo "Registering protocol handler"
-       if [ ! -e "$HOME/.local/share/applications/" ]; then
-          mkdir -p "$HOME/.local/share/applications/"
-       fi
-       cat - > "$HOME/.local/share/applications/$HANDLER" <<EOF
+  HANDLER="blockstack.desktop"
+  if [ ! -e "$HOME/.local/share/applications/$HANDLER" ]; then
+    echo "Registering protocol handler"
+    if [ ! -e "$HOME/.local/share/applications/" ]; then
+      mkdir -p "$HOME/.local/share/applications/"
+    fi
+    cat - > "$HOME/.local/share/applications/$HANDLER" <<EOF
 [Desktop Entry]
 Type=Application
 Terminal=false
@@ -213,9 +143,9 @@ Exec=bash -c 'xdg-open http://localhost:8888/auth?authRequest=\$(echo "%u" | sed
 Name=Blockstack-Browser
 MimeType=x-scheme-handler/blockstack;
 EOF
-       chmod +x "$HOME/.local/share/applications/$HANDLER"
-       xdg-mime default "$HANDLER" x-scheme-handler/blockstack
-    fi
+    chmod +x "$HOME/.local/share/applications/$HANDLER"
+    xdg-mime default "$HANDLER" x-scheme-handler/blockstack
+  fi
 }
 
 case $1 in
@@ -234,20 +164,11 @@ case $1 in
   logs)
     logs
     ;;
-  build)
-    build
-    ;;
   enter)
     enter
     ;;
   pull)
     pull
-    ;;
-  push)
-    push
-    ;;
-  build)
-    build
     ;;
   version)
     version

--- a/browser-core-docker/launcher
+++ b/browser-core-docker/launcher
@@ -12,11 +12,6 @@ export CORETAG="$TAG-browser"
 export CORE_IMAGE=quay.io/blockstack/blockstack-core:$CORETAG
 export BROWSER_IMAGE=quay.io/blockstack/blockstack-browser:$TAG
 
-# Default to setting blockstack to debug mode
-if [ "$BLOCKSTACK_DEBUG" != "0" ]; then
-    BLOCKSTACK_DEBUG=1
-fi
-
 # Local Blockstack directory
 if [ -z "${BLOCKSTACK_DATA}" ]; then
   export DATA_DIR="$HOME/.blockstack"


### PR DESCRIPTION
Instead of the `launcher` script needing to do OS-sniffing and other tricks to manage the containers, offload that onto Docker-Compose.