### PR TITLE
Add commands for running `blockstack-core` to launcher

### DIFF
--- a/browser-core-docker/launcher
+++ b/browser-core-docker/launcher
@@ -170,6 +170,7 @@ blockstack docker launcher commands:
   init-core -> fast_sync a blockstack-core node
   start-core -> start a blockstack-core node
   stop-core -> stop a running blockstack-core node
+  pull-core -> pull the blockstack-core image
 EOF
 }
 
@@ -259,6 +260,10 @@ start-core () {
   fi
 }
 
+pull-core () {
+  docker pull ${coreimage}
+}
+
 stop-core () {
   bsd=$(docker ps -a -f name=$blockstackdcontainer -q)
   if [ ! -z "$bsd" ]; then
@@ -311,6 +316,9 @@ case $1 in
     ;;
   stop-core)
     stop-core
+    ;;
+  pull-core)
+    pull-core
     ;;
   *)
     commands

--- a/browser-core-docker/launcher
+++ b/browser-core-docker/launcher
@@ -2,21 +2,28 @@
 
 # This script provides a simple interface for folks to use the docker install
 
-TAG=latest
+TAG=v0.18.1
 
 CORETAG="$TAG-browser"
+COREVERSION="0.17.0.9"
 
 coreimage=quay.io/blockstack/blockstack-core:$CORETAG
 browserimage=quay.io/blockstack/blockstack-browser:$TAG
 
 # Local Blockstack directory
 homedir=$HOME/.blockstack
+# Local Blockstack core directory
+blockstackddir=$HOME/.blockstack-server
+# Blockstackd directory inside container
+blockstackdcontainerdir=/root/.blockstack-server
 # Blockstack Directory inside container
 containerdir=/root/.blockstack
 # Name of Blockstack API container
 corecontainer=blockstack-api
 # Name of Blockstack Browser container
 browsercontainer=blockstack-browser
+# Name of the blockstack-core container
+blockstackdcontainer=blockstack-core
 # Local temporary directory
 tmpdir=/tmp/.blockstack_tmp
 if [ ! -e $tmpdir ]; then
@@ -158,6 +165,11 @@ blockstack docker launcher commands:
   stop -> stop the blockstack browser server
   logs -> access the logs from the blockstack browser server
   enter -> exec into the running docker container
+  version -> print the version number
+
+  init-core -> fast_sync a blockstack-core node
+  start-core -> start a blockstack-core node
+  stop-core -> stop a running blockstack-core node
 EOF
 }
 
@@ -218,6 +230,45 @@ EOF
     fi
 }
 
+init-core () {
+  echo "Initializing Blockstack Core node. This task runs in the background and may take up to 20 minutes..."
+  mkdir -p $blockstackddir
+  # Make the config file so that fast_sync doesn't fail
+  printf "[bitcoind]\np2p_port = 8333\nregtest = False\nspv_path = /root/.virtualchain-spv-headers.dat\nserver = bitcoin.blockstack.com\npasswd = blockstacksystem\nuser = blockstack\ntimeout = 300\nport = 8332\nuse_https = False\n[blockstack]\nemail = foo@bar.com\nserver_version = $COREVERSION\n" > $blockstackddir/blockstack-server.ini
+  docker run -d --rm \
+    -v $blockstackddir/:/root/.blockstack-server/ \
+    --name blockstack-core-init \
+    $coreimage \
+    blockstack-core --debug fast_sync http://fast-sync.blockstack.org/snapshot.bsk > /dev/null
+}
+
+start-core () {
+  # Check for the blockstack-core containers are running or stopped.
+  if [ "$(docker ps -q -f name=$blockstackdcontainer)" ]; then
+    echo "blockstack-core container is already running"
+    exit 1
+  elif [ ! "$(docker ps -q -f name=$blockstackdcontainer)" ]; then
+    if [ "$(docker ps -aq -f status=exited -f name=$blockstackdcontainer)" ]; then
+      # cleanup old containers if they are still around
+      echo "removing old blockstack-core containers..."
+      docker rm $(docker ps -aq -f status=exited -f name=$blockstackdcontainer)
+    fi
+
+    # If there are no existing blockstack-browser-* containers, run them
+    docker run -d --name $blockstackdcontainer -v $blockstackddir:$blockstackdcontainerdir -p 6264:6264 $coreimage blockstack-core start --foreground --debug
+  fi
+}
+
+stop-core () {
+  bsd=$(docker ps -a -f name=$blockstackdcontainer -q)
+  if [ ! -z "$bsd" ]; then
+    echo "stopping the running blockstack-api container"
+    docker stop $bsd
+    docker rm $bsd
+    rm $blockstackddir/blockstack-server.pid > /dev/null
+  fi
+}
+
 case $1 in
   create-linux-protocol-handler)
     create-linux-protocol-handler
@@ -251,6 +302,15 @@ case $1 in
     ;;
   version)
     version
+    ;;
+  start-core)
+    start-core
+    ;;
+  init-core)
+    init-core
+    ;;
+  stop-core)
+    stop-core
     ;;
   *)
     commands

--- a/browser-core-docker/launcher
+++ b/browser-core-docker/launcher
@@ -2,7 +2,7 @@
 
 # This script provides a simple interface for folks to use the docker install
 
-TAG=v0.18.1
+TAG=latest
 
 CORETAG="$TAG-browser"
 COREVERSION="0.17.0.9"


### PR DESCRIPTION
This is in reference to `https://github.com/blockstack/blockstack-core/issues/656`

@kantai @larrysalibra 

I would love some eyes on this. There is also going to be a `blockstack-core` PR that depends on this.