### PR TITLE
Fix desktop handler

### DIFF
--- a/blockstack-toolbox-windows/script/build-windows
+++ b/blockstack-toolbox-windows/script/build-windows
@@ -14,15 +14,17 @@ push=false
 
 if [ -f secrets ]; then
     echo "Secrets file found, attempting to push to Azure blob storage"
-    if [ "$BUILD_TAG" ]; then
-        TAG="$BUILD_TAG"
-    else
-        TAG=$(git symbolic-ref -q --short HEAD || git describe --tags --exact-match)
-    fi
-    sed -i -e "s/TAG=latest/TAG=${TAG}/" ./windows/launcher
     . secrets
     push=true
 fi
+
+if [ "$BUILD_TAG" ]; then
+    TAG="$BUILD_TAG"
+else
+    TAG=$(git symbolic-ref -q --short HEAD || git describe --tags --exact-match)
+fi
+sed -i -e "s/TAG=latest/TAG=${TAG}/" ./windows/launcher
+
 
 docker build \
 	-t windows-installer \
@@ -40,7 +42,7 @@ docker build \
 
 CONTAINER="$(docker run -d windows-installer)"
 mkdir -p dist
-docker cp "${CONTAINER}":/installer/Output/BlockstackToolbox.exe dist/
+docker cp "${CONTAINER}":/installer/Output/BlockstackToolbox.exe ../dist/
 docker rm "${CONTAINER}" 2>/dev/null || true
 
 if [ "$push" == "true" ]; then

--- a/blockstack-toolbox-windows/script/sign-windows
+++ b/blockstack-toolbox-windows/script/sign-windows
@@ -2,7 +2,6 @@
 
 # requires secrets --> key.pem + cert.pem
 
-openssl rsa -in secrets/key.pem -outform DER -out secrets/signer.key
 openssl crl2pkcs7 -nocrl -certfile secrets/cert.pem -outform DER -out secrets/cert.spc
 osslsigncode -spc secrets/cert.spc -key secrets/signer.key -t http://timestamp.verisign.com/scripts/timstamp.dll -in dist/BlockstackToolbox.exe -out dist/BlockstackToolboxSigned.exe
 

--- a/blockstack-toolbox-windows/windows/Toolbox.iss
+++ b/blockstack-toolbox-windows/windows/Toolbox.iss
@@ -166,6 +166,16 @@ begin
   TrackEventWithProperties(name, '');
 end;
 
+function DockerInstalled(): Boolean;
+begin
+  Result := DirExists('C:\Program Files\Docker')
+end;
+
+function HyperVInstalled(): Boolean;
+begin
+  Result := DirExists('C:\Program Files\Hyper-V')
+end;
+
 function NeedToInstallVirtualBox(): Boolean;
 begin
   // TODO: Also compare versions
@@ -188,16 +198,6 @@ begin
     Result := GetEnv('VBOX_MSI_INSTALL_PATH')
 end;
 
-function DockerInstalled(): Boolean;
-begin
-  Result := not DirExists('C:\Program Files\Docker')
-end;
-
-function HyperVInstalled(): Boolean;
-begin
-  Result := not DirExists('C:\Program Files\Hyper-V')
-end;
-
 function NeedToInstallGit(): Boolean;
 begin
   // TODO: Find a better way to see if Git is installed
@@ -216,15 +216,21 @@ begin
 
 
     if HyperVInstalled() and (not DockerInstalled()) then
+    begin
         // TODO: need to error out.
         MsgBox('It looks like you have Hyper-V installed, but not Docker. In order to use Blockstack with Hyper-V, you must install Docker for Windows first.', mbCriticalError, MB_OK);
         exit;
+    end
     else
+    begin
       if HyperVInstalled() and DockerInstalled() then
+      begin
         Wizardform.ComponentsList.Checked[2] := False; // No Docker
         Wizardform.ComponentsList.Checked[3] := False; // No DockerMachine
         Wizardform.ComponentsList.Checked[4] := False; // No VirtualBox
+      end
       else
+      begin
         Wizardform.ComponentsList.Checked[1] := False; // No Docker4Win scripts
         Wizardform.ComponentsList.Checked[4] := NeedToInstallVirtualBox();
         Wizardform.ComponentsList.ItemEnabled[4] := not NeedToInstallVirtualBox();
@@ -255,10 +261,11 @@ var
   ResultCode: Integer;
 begin
   if NeedToInstallVirtualBox() then
+  begin
     WizardForm.FilenameLabel.Caption := 'installing VirtualBox'
     if not Exec(ExpandConstant('msiexec'), ExpandConstant('/qn /i "{app}\installers\virtualbox\virtualbox.msi" /norestart'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
       MsgBox('virtualbox install failure', mbInformation, MB_OK);
-    end;
+  end;
 end;
 
 procedure RunInstallGit();

--- a/blockstack-toolbox-windows/windows/Toolbox.iss
+++ b/blockstack-toolbox-windows/windows/Toolbox.iss
@@ -58,7 +58,6 @@ Name: vbox_ndis5; Description: "Install VirtualBox with NDIS5 driver[default NDI
 Name: "BlockstackDocker"; Description: "Blockstack Launcher" ; Types: full custom; Flags: fixed
 Name: "Docker"; Description: "Docker Client for Windows" ; Types: full custom; Flags: fixed
 Name: "DockerMachine"; Description: "Docker Machine for Windows" ; Types: full custom; Flags: fixed
-Name: "DockerCompose"; Description: "Docker Compose for Windows" ; Types: full custom
 Name: "VirtualBox"; Description: "VirtualBox"; Types: full custom; Flags: disablenouninstallwarning
 Name: "Git"; Description: "Git for Windows"; Types: full custom; Flags: disablenouninstallwarning
 
@@ -70,7 +69,6 @@ Source: ".\docker_shell.sh"; DestDir: "{app}"; Flags: ignoreversion; Components:
 Source: ".\blockstack.bat"; DestDir: "{app}"; Flags: ignoreversion; Components: "BlockstackDocker"
 Source: ".\launcher"; DestDir: "{app}"; Flags: ignoreversion; Components: "BlockstackDocker"
 Source: "{#dockerMachineCli}"; DestDir: "{app}"; Flags: ignoreversion; Components: "DockerMachine"
-Source: "{#dockerComposeCli}"; DestDir: "{app}"; Flags: ignoreversion; Components: "DockerCompose"
 Source: "{#b2dIsoPath}"; DestDir: "{app}"; Flags: ignoreversion; Components: "DockerMachine"; AfterInstall: CopyBoot2DockerISO()
 Source: "{#git}"; DestDir: "{app}\installers\git"; DestName: "git.exe"; AfterInstall: RunInstallGit();  Components: "Git"
 Source: "{#virtualBoxCommon}"; DestDir: "{app}\installers\virtualbox"; Components: "VirtualBox"
@@ -201,8 +199,8 @@ begin
 
     // Don't do this until we can compare versions
     // Wizardform.ComponentsList.Checked[3] := NeedToInstallVirtualBox();
-    Wizardform.ComponentsList.ItemEnabled[4] := not NeedToInstallVirtualBox();
-    Wizardform.ComponentsList.Checked[5] := NeedToInstallGit();
+    Wizardform.ComponentsList.ItemEnabled[3] := not NeedToInstallVirtualBox();
+    Wizardform.ComponentsList.Checked[4] := NeedToInstallGit();
 end;
 
 function InitializeSetup(): boolean;

--- a/blockstack-toolbox-windows/windows/docker_shell.sh
+++ b/blockstack-toolbox-windows/windows/docker_shell.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-BROWSER_CONTAINER_REPO=quay.io/blockstack/blockstack-browser
-CORE_CONTAINER_REPO=quay.io/blockstack/blockstack-core
-
 trap '[ "$?" -eq 0 ] || read -p "Looks like something went wrong in step ´$STEP´... Press any key to continue..."' EXIT
 
 # TODO: I'm sure this is not very robust.  But, it is needed for now to ensure
@@ -108,7 +105,7 @@ cat << EOF
 
 EOF
 echo -e "${BLUE}docker${NC} is configured to use the ${GREEN}${VM}${NC} machine with IP ${GREEN}$(${DOCKER_MACHINE} ip ${VM})${NC}"
-echo "For help getting started, check out the docs at https://docs.docker.com"
+echo "For help getting started, check out https://blockstack.org"
 echo
 cd
 

--- a/blockstack-toolbox-windows/windows/docker_shell_d4w.sh
+++ b/blockstack-toolbox-windows/windows/docker_shell_d4w.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+cat << EOF
+
+    ...     ...
+   .   .   .   .
+   ,,..    ,,..
+                    B L O C K S T A C K
+    ...     ...
+   .   .   .   .
+   ,,..    ,,..
+
+
+
+EOF
+echo "For help getting started with Blockstack, check out https://blockstack.org"
+echo
+cd
+

--- a/blockstack-toolbox-windows/windows/docker_shell_d4w.sh
+++ b/blockstack-toolbox-windows/windows/docker_shell_d4w.sh
@@ -17,3 +17,4 @@ echo "For help getting started with Blockstack, check out https://blockstack.org
 echo
 cd
 
+exec "$BASH" --login -i

--- a/blockstack-toolbox-windows/windows/start.sh
+++ b/blockstack-toolbox-windows/windows/start.sh
@@ -124,6 +124,11 @@ launcher start
 trap "launcher stop ; echo 'Closing'" SIGINT SIGTERM
 trap "launcher stop ; echo 'Closing'" EXIT
 
+echo "Blockstack's background processes are listening on ports 6270 and 1337"
+echo
+echo "The Blockstack browser portal is listening on port 8888"
+echo "To connect to the Blockstack browser, open http://localhost:8888 in your browser"
+echo
 echo "Blockstack is running. Hit Ctrl-C to Exit."
 
 while :

--- a/blockstack-toolbox-windows/windows/start.sh
+++ b/blockstack-toolbox-windows/windows/start.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-BROWSER_CONTAINER_REPO=quay.io/blockstack/blockstack-browser
-CORE_CONTAINER_REPO=quay.io/blockstack/blockstack-core
-
 trap '[ "$?" -eq 0 ] || read -p "Looks like something went wrong in step ´$STEP´... Press any key to continue..."' EXIT
 
 # TODO: I'm sure this is not very robust.  But, it is needed for now to ensure
@@ -105,6 +102,7 @@ cat << EOF
    ,,..    ,,..
 
 
+   Fetching latest Blockstack Docker Images...
 
 EOF
 echo -e "${BLUE}docker${NC} is configured to use the ${GREEN}${VM}${NC} machine with IP ${GREEN}$(${DOCKER_MACHINE} ip ${VM})${NC}"

--- a/blockstack-toolbox-windows/windows/start.sh
+++ b/blockstack-toolbox-windows/windows/start.sh
@@ -117,6 +117,22 @@ export -f docker
 
 launcher pull
 
+clear
+cat << EOF
+
+    ...     ...
+   .   .   .   .
+   ,,..    ,,..
+                    B L O C K S T A C K
+    ...     ...
+   .   .   .   .
+   ,,..    ,,..
+
+
+   Starting Blockstack daemon...
+
+EOF
+
 launcher start
 
 trap "launcher stop ; echo 'Closing'" SIGINT SIGTERM

--- a/blockstack-toolbox-windows/windows/start_d4w.sh
+++ b/blockstack-toolbox-windows/windows/start_d4w.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+cat << EOF
+
+    ...     ...
+   .   .   .   .
+   ,,..    ,,..
+                    B L O C K S T A C K
+    ...     ...
+   .   .   .   .
+   ,,..    ,,..
+
+
+   Fetching latest Blockstack Docker Images...
+
+EOF
+
+export WIN_HYPERV=1
+
+launcher pull
+
+launcher start
+
+trap "launcher stop ; echo 'Closing'" SIGINT SIGTERM
+trap "launcher stop ; echo 'Closing'" EXIT
+
+echo "Blockstack's background processes are listening on ports 6270 and 1337"
+echo
+echo "The Blockstack browser portal is listening on port 8888"
+echo "To connect to the Blockstack browser, open http://localhost:8888 in your browser"
+echo
+echo "Blockstack is running. Hit Ctrl-C to Exit."
+
+while :
+do
+  sleep 60
+done

--- a/blockstack-toolbox-windows/windows/start_d4w.sh
+++ b/blockstack-toolbox-windows/windows/start_d4w.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+trap '[ "$?" -eq 0 ] || read -p "Looks like something went wrong ... Press any key to continue..."' EXIT
+
 cat << EOF
 
     ...     ...
@@ -16,8 +18,25 @@ cat << EOF
 EOF
 
 export WIN_HYPERV=1
+set -e
 
 launcher pull
+
+clear
+cat << EOF
+
+    ...     ...
+   .   .   .   .
+   ,,..    ,,..
+                    B L O C K S T A C K
+    ...     ...
+   .   .   .   .
+   ,,..    ,,..
+
+
+   Starting Blockstack daemon...
+
+EOF
 
 launcher start
 
@@ -31,7 +50,4 @@ echo "To connect to the Blockstack browser, open http://localhost:8888 in your b
 echo
 echo "Blockstack is running. Hit Ctrl-C to Exit."
 
-while :
-do
-  sleep 60
-done
+bash --login -c 'while : ; do sleep 60; done'

--- a/browser-core-docker/launcher
+++ b/browser-core-docker/launcher
@@ -250,7 +250,7 @@ create-linux-protocol-handler () {
 [Desktop Entry]
 Type=Application
 Terminal=false
-Exec=bash -c 'xdg-open http://localhost:8888/auth?authRequest=\$(echo "%u" | sed s/blockstack://)'
+Exec=bash -c 'xdg-open http://localhost:8888/auth?authRequest=\$(echo "%u" | sed s#blockstack:///##)'
 Name=Blockstack-Browser
 MimeType=x-scheme-handler/blockstack;
 EOF

--- a/browser-core-docker/launcher
+++ b/browser-core-docker/launcher
@@ -3,11 +3,22 @@
 # This script provides a simple interface for folks to use the docker install
 
 TAG=latest
+if [ "$BLOCKSTACK_TAG" ]; then
+   TAG="$BLOCKSTACK_TAG"
+fi
 
 CORETAG="$TAG-browser"
 
 coreimage=quay.io/blockstack/blockstack-core:$CORETAG
 browserimage=quay.io/blockstack/blockstack-browser:$TAG
+
+if [ "$CORE_IMAGE" ]; then
+    coreimage="$CORE_IMAGE"
+fi
+
+if [ "$BROWSER_IMAGE" ]; then
+    browserimage="$BROWSER_IMAGE"
+fi
 
 # Local Blockstack directory
 homedir=$HOME/.blockstack
@@ -73,24 +84,30 @@ start-containers () {
       docker rm $corecontainer
     fi
 
-    if [ "$BLOCKSTACK_DEBUG" == "1" ]; then
-      runcommand="bash"
-    else
-      runcommand="blockstack api start-foreground --password $password --api_password $password"
-    fi
-
     # If there is no existing $corecontainer container, run one
     if [[ $(uname) == 'Linux' ]]; then
-      docker run -dt --name $corecontainer -v "$tmpdir":/tmp -v "$homedir":$containerdir -p 6270:6270 $coreimage $runcommand
+      docker run -dt --name $corecontainer -v "$tmpdir":/tmp -v "$homedir":$containerdir -p 6270:6270 $coreimage bash
     elif [[ $(uname) == 'Darwin' ]]; then
-      docker run -dt --name $corecontainer -v "$tmpdir":/tmp -v "$homedir":$containerdir -p 6270:6270 $coreimage $runcommand
+      docker run -dt --name $corecontainer -v "$tmpdir":/tmp -v "$homedir":$containerdir -p 6270:6270 $coreimage bash
     elif [[ $(uname) == 'Windows' || $(uname) == 'MINGW64_NT-10.0' ]]; then
-      docker run -dt --name $corecontainer -v "$tmpdir":/tmp -v "$homedir":$containerdir -p 6270:6270 $coreimage $runcommand
+      docker run -dt --name $corecontainer -v "$tmpdir":/tmp -v "$homedir":$containerdir -p 6270:6270 $coreimage bash
     fi
 
     if [ "$BLOCKSTACK_DEBUG" == "1" ]; then
-      docker exec -t $corecontainer blockstack api start --debug --password $password --api_password $password
+      runcommand="blockstack api start --debug --password $password --api_password $password"
+    else
+      runcommand="blockstack api start --password $password --api_password $password"
     fi
+
+    docker exec -t $corecontainer $runcommand
+    curl -s http://localhost:6270/v1/ping | grep -q "alive"
+    running=$?
+    if [ $running -ne 0 ]; then
+        echo "Failed to start Blockstack daemon -- is your password correct?"
+        stop
+        exit 1
+    fi
+
   fi
 
   # Check for the blockstack-browser-* containers are running or stopped.

--- a/browser-core-docker/launcher
+++ b/browser-core-docker/launcher
@@ -28,6 +28,12 @@ fi
 
 # Local Blockstack directory
 homedir=$HOME/.blockstack
+# Local Blockstack core directory
+blockstackddir=$HOME/.blockstack-server
+# Blockstackd directory inside container
+blockstackdcontainerdir=/root/.blockstack-server
+# Blockstack Directory inside container
+containerdir=/root/.blockstack
 # Name of Blockstack API container
 corecontainer=blockstack-api
 # Name of Blockstack Browser container
@@ -187,18 +193,12 @@ blockstack docker launcher commands:
   stop  -> stop the blockstack browser server
   logs  -> access the logs from the blockstack browser server
   enter -> exec into the running docker container
+  version -> print the version number
 
-To get started, use
-
- $  ./Blockstack-for-Linux.sh pull
- $  ./Blockstack-for-Linux.sh start
-
-This *requires* Docker to run.
-
-And this will start the environment for running the Blockstack Browser
-
-Note: the Docker containers mount your /home/<user>/.blockstack directory
-
+  init-core -> fast_sync a blockstack-core node
+  start-core -> start a blockstack-core node
+  stop-core -> stop a running blockstack-core node
+  pull-core -> pull the blockstack-core image
 EOF
 }
 

--- a/browser-core-docker/launcher
+++ b/browser-core-docker/launcher
@@ -20,6 +20,12 @@ if [ "$BROWSER_IMAGE" ]; then
     browserimage="$BROWSER_IMAGE"
 fi
 
+
+# Default to setting blockstack to debug mode
+if [ "$BLOCKSTACK_DEBUG" != "0" ]; then
+    BLOCKSTACK_DEBUG=1
+fi
+
 # Local Blockstack directory
 homedir=$HOME/.blockstack
 # Blockstack Directory inside container

--- a/browser-core-docker/launcher
+++ b/browser-core-docker/launcher
@@ -28,8 +28,6 @@ fi
 
 # Local Blockstack directory
 homedir=$HOME/.blockstack
-# Blockstack Directory inside container
-containerdir=/root/.blockstack
 # Name of Blockstack API container
 corecontainer=blockstack-api
 # Name of Blockstack Browser container
@@ -42,6 +40,17 @@ fi
 # set password blank so we know when to prompt
 password=0
 
+if [ $WIN_HYPERV == '1' ]; then
+    coremount_tmp="/$tmpdir":'/tmp'
+    coremount_home="/$homedir":'/root/.blockstack'
+    client_ini='//root/.blockstack/client.ini'
+    prefix='winpty'
+else
+    coremount_tmp="/$tmpdir":'/tmp'
+    coremount_home="$homedir":'/root/.blockstack'
+    client_ini='/root/.blockstack/client.ini'
+    prefix=''
+fi
 
 build () {
   echo "Building blockstack docker image. This might take a minute..."
@@ -53,10 +62,10 @@ create-wallet () {
     echo "Need to input new wallet password when running setup: ./launcher create-wallet mypass"
     exit 1
   fi
-  docker run -it -v "$homedir":$containerdir $coreimage blockstack setup -y --password $1
+  $prefix docker run -it -v $coremount_home $coreimage blockstack setup -y --password $1
 
   # Use init containers to set the API bind to 0.0.0.0
-  docker run -it -v "$homedir":$containerdir $coreimage sed -i 's/api_endpoint_bind = localhost/api_endpoint_bind = 0.0.0.0/' $containerdir/client.ini
+  $prefix docker run -it -v $coremount_home $coreimage sed -i 's/api_endpoint_bind = localhost/api_endpoint_bind = 0.0.0.0/' "$client_ini"
 }
 
 start-containers () {
@@ -91,13 +100,7 @@ start-containers () {
     fi
 
     # If there is no existing $corecontainer container, run one
-    if [[ $(uname) == 'Linux' ]]; then
-      docker run -dt --name $corecontainer -v "$tmpdir":/tmp -v "$homedir":$containerdir -p 6270:6270 $coreimage bash
-    elif [[ $(uname) == 'Darwin' ]]; then
-      docker run -dt --name $corecontainer -v "$tmpdir":/tmp -v "$homedir":$containerdir -p 6270:6270 $coreimage bash
-    elif [[ $(uname) == 'Windows' || $(uname) == 'MINGW64_NT-10.0' ]]; then
-      docker run -dt --name $corecontainer -v "$tmpdir":/tmp -v "$homedir":$containerdir -p 6270:6270 $coreimage bash
-    fi
+    docker run -dt --name $corecontainer -v $coremount_tmp -v $coremount_home -p 6270:6270 $coreimage bash
 
     if [ "$BLOCKSTACK_DEBUG" == "1" ]; then
       runcommand="blockstack api start --debug --password $password --api_password $password"
@@ -105,7 +108,7 @@ start-containers () {
       runcommand="blockstack api start --password $password --api_password $password"
     fi
 
-    docker exec -t $corecontainer $runcommand
+    $prefix docker exec -t $corecontainer $runcommand
     curl -s http://localhost:6270/v1/ping | grep -q "alive"
     running=$?
     if [ $running -ne 0 ]; then

--- a/browser-core-docker/launcher
+++ b/browser-core-docker/launcher
@@ -40,7 +40,7 @@ fi
 # set password blank so we know when to prompt
 password=0
 
-if [ $WIN_HYPERV == '1' ]; then
+if [ "$WIN_HYPERV" == '1' ]; then
     coremount_tmp="/$tmpdir":'/tmp'
     coremount_home="/$homedir":'/root/.blockstack'
     client_ini='//root/.blockstack/client.ini'
@@ -90,8 +90,8 @@ start-containers () {
 
   # Check for the blockstack-api container is running or stopped.
   if [ "$(docker ps -q -f name=$corecontainer)" ]; then
-    echo "blockstack core container is already running"
-    exit 1
+    echo "Blockstack core container is already running -- restarting it."
+    stop
   elif [ ! "$(docker ps -q -f name=$corecontainer)" ]; then
     if [ "$(docker ps -aq -f status=exited -f name=$corecontainer)" ]; then
       # cleanup old container if its still around
@@ -103,12 +103,12 @@ start-containers () {
     docker run -dt --name $corecontainer -v $coremount_tmp -v $coremount_home -p 6270:6270 $coreimage bash
 
     if [ "$BLOCKSTACK_DEBUG" == "1" ]; then
-      runcommand="blockstack api start --debug --password $password --api_password $password"
+      runcommand="blockstack api start --debug --password $password --api_password $password 2>/dev/null"
     else
       runcommand="blockstack api start --password $password --api_password $password"
     fi
 
-    $prefix docker exec -t $corecontainer $runcommand
+    $prefix docker exec -it $corecontainer $runcommand
     curl -s http://localhost:6270/v1/ping | grep -q "alive"
     running=$?
     if [ $running -ne 0 ]; then
@@ -121,8 +121,8 @@ start-containers () {
 
   # Check for the blockstack-browser-* containers are running or stopped.
   if [ "$(docker ps -q -f name=$browsercontainer)" ]; then
-    echo "browser containers are already running"
-    exit 1
+    echo "Blockstack browser is already running -- restarting it."
+    stop
   elif [ ! "$(docker ps -q -f name=$browsercontainer)" ]; then
     if [ "$(docker ps -aq -f status=exited -f name=$browsercontainer)" ]; then
       # cleanup old containers if they are still around
@@ -151,6 +151,7 @@ stop () {
   cc=$(docker ps -f name=$corecontainer -q)
   if [ ! -z "$cc" ]; then
     echo "stopping the running blockstack-api container"
+    $prefix docker exec -dt $corecontainer blockstack api stop
     docker stop $cc
     docker rm $cc
   fi

--- a/browser-core-docker/launcher
+++ b/browser-core-docker/launcher
@@ -103,7 +103,7 @@ start-containers () {
     docker run -dt --name $corecontainer -v $coremount_tmp -v $coremount_home -p 6270:6270 $coreimage bash
 
     if [ "$BLOCKSTACK_DEBUG" == "1" ]; then
-      runcommand="blockstack api start --debug --password $password --api_password $password 2>/dev/null"
+      runcommand="blockstack api start --debug --password $password --api_password $password"
     else
       runcommand="blockstack api start --password $password --api_password $password"
     fi

--- a/browser-core-docker/launcher
+++ b/browser-core-docker/launcher
@@ -180,11 +180,25 @@ push () {
 
 commands () {
   cat <<-EOF
+
 blockstack docker launcher commands:
+  pull  -> fetch docker containers from quay
   start -> start the blockstack browser server
-  stop -> stop the blockstack browser server
-  logs -> access the logs from the blockstack browser server
+  stop  -> stop the blockstack browser server
+  logs  -> access the logs from the blockstack browser server
   enter -> exec into the running docker container
+
+To get started, use
+
+ $  ./Blockstack-for-Linux.sh pull
+ $  ./Blockstack-for-Linux.sh start
+
+This *requires* Docker to run.
+
+And this will start the environment for running the Blockstack Browser
+
+Note: the Docker containers mount your /home/<user>/.blockstack directory
+
 EOF
 }
 

--- a/deploy-pypi.sh
+++ b/deploy-pypi.sh
@@ -23,9 +23,8 @@ for PKG_NAME in $(ls "$PKG_BASE"); do
    echo "Uploading $PKG_NAME"
    "$PYPI_UPLOADER" "$PKG_DIR" "$METADATA_DIR" "$PYPI_SECRETS"
 
-   if [ $? -ne 0 ]; then 
+   if [ $? -ne 0 ]; then
       echo "Failed to upload $PKG_NAME to PyPI"
-      exit 1
    fi
 done
 

--- a/distribute-linux-launcher
+++ b/distribute-linux-launcher
@@ -15,12 +15,19 @@ TAG="latest"
 
 push=false
 
+if [ "$BUILD_TAG" ]; then
+    TAG="$BUILD_TAG"
+else
+    TAG=$(git symbolic-ref -q --short HEAD || git describe --tags --exact-match)
+fi
+sed -i -e "s/TAG=latest/TAG=${TAG}/" ./dist/linux-launcher/launcher
+
+
 if [ -f azure_secrets ]; then
     echo "Secrets file found, attempting to push to Azure blob storage"
     TAG=$(git symbolic-ref -q --short HEAD || git describe --tags --exact-match)
-    sed -i -e "s/TAG=latest/TAG=${TAG}/" ./dist/linux-launcher/launcher
     . azure_secrets
-#    push=true
+    push=true
 fi
 
 if [ "$push" == "true" ]; then

--- a/pypi.sh
+++ b/pypi.sh
@@ -51,8 +51,8 @@ pushd "$PKG_SRC" > /dev/null
 # register
 test -d dist/ && rm -rf dist/
 python ./setup.py sdist
-   
-# upload 
+
+# upload
 TWINE_USERNAME="$PYPI_USER" TWINE_PASSWORD="$PYPI_SECRET" twine upload dist/*
 RC=$?
 


### PR DESCRIPTION
The desktop handler registered with xdg-open does not work. It get's a URI of format:

blockstack:///AUTH_TOKEN

but only strips away 'blockstack:' leaving the AUTH_TOKEN as "///AUTH_TOKEN" instead of "AUTH_TOKEN"

This simple change fixes that.
It addresses and finally solves: https://github.com/blockstack/blockstack-browser/issues/324