### PR TITLE
Fix desktop handler for Linux-systems with xdg

### DIFF
--- a/browser-core-docker/launcher
+++ b/browser-core-docker/launcher
@@ -250,7 +250,7 @@ create-linux-protocol-handler () {
 [Desktop Entry]
 Type=Application
 Terminal=false
-Exec=bash -c 'xdg-open http://localhost:8888/auth?authRequest=\$(echo "%u" | sed s/blockstack://)'
+Exec=bash -c 'xdg-open http://localhost:8888/auth?authRequest=\$(echo "%u" | sed s#blockstack:///##)'
 Name=Blockstack-Browser
 MimeType=x-scheme-handler/blockstack;
 EOF


### PR DESCRIPTION
The blockstack url generated is "blockstack:///AUTH_TOKEN", but
the sed'ing happening when starting only removes "blockstack:", thus
leaving the "AUTH_TOKEN" as "///AUTH_TOKEN", which doesn't work.

This patch fixes that.